### PR TITLE
Adjust deploy in .aicoe.yaml for handling correctly the overlays context path

### DIFF
--- a/.aicoe-ci.yaml
+++ b/.aicoe-ci.yaml
@@ -10,6 +10,6 @@ build:
   registry-secret: thoth-station-thoth-pusher-secret
 deploy:
   project-org: "thoth-station"
-  project-name: "thoth-deployment-examples"
+  project-name: "elyra-aidevsecops-tutorial"
   image-name: "elyra-aidevsecops-tutorial"
   overlay-contextpath: "elyra-aidevsecops-tutorial/manifests/overlays/test/imagestreamtag.yaml"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ repos:
       - id: remove-tabs
 
   - repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -28,7 +28,7 @@ repos:
       - id: pydocstyle
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v3.4.0
     hooks:
       - id: check-toml
       - id: check-yaml
@@ -36,7 +36,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.790
+    rev: v0.800
     hooks:
       - id: mypy
         exclude: '^(docs|tasks|tests)|setup\.py'

--- a/manifests/overlays/test/imagestreamtag.yaml
+++ b/manifests/overlays/test/imagestreamtag.yaml
@@ -8,7 +8,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/elyra-aidevsecops-tutorial:v0.0.1
+      name: quay.io/thoth-station/elyra-aidevsecops-tutorial:v0.1.0
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

In this way Tekton pipeline will update automatically the tag.

## Related Issues and Dependencies

```
+ export 'GIT_SSH_COMMAND=ssh -i ~/.ssh/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+ GIT_SSH_COMMAND='ssh -i ~/.ssh/id_rsa -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
+ git clone git@github.com:thoth-station/thoth-deployment-examples /workspace/configrepo
Cloning into '/workspace/configrepo'...
Warning: Permanently added 'github.com,140.82.113.3' (RSA) to the list of known hosts.
ERROR: Repository not found.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.`
```
Tekton pipeline: https://tekton-dashboard-openshift-pipelines.apps.ocp4.prod.psi.redhat.com/#/namespaces/aicoe-infra-prod/pipelineruns/tag-release-wmpbg