### PR TITLE
Add flask exporter prometheus

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ matplotlib = "*"
 prometheus-client = "*"
 flask-cors = "*"
 gunicorn = "*"
+prometheus-flask-exporter = "*"
 
 [dev-packages]
 flake8 = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3a8a34b41de5c17d63e387359c14cef5a1274329e1743271c732d0a35b5365ce"
+            "sha256": "246934557b9b1826371729328e807e88afa0ebb7bb2907939dd5ddf0348746ee"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -480,6 +480,13 @@
             ],
             "index": "pypi",
             "version": "==0.9.0"
+        },
+        "prometheus-flask-exporter": {
+            "hashes": [
+                "sha256:01c8282eb695596531f29f4869c1b127e1918af4f191f1215c4b0b0d081f757e"
+            ],
+            "index": "pypi",
+            "version": "==0.18.1"
         },
         "protobuf": {
             "hashes": [

--- a/wsgi.py
+++ b/wsgi.py
@@ -28,6 +28,7 @@ from flask import Flask
 from flask import request
 from flask import redirect
 
+from prometheus_flask_exporter import PrometheusMetrics
 from prometheus_client import generate_latest, Gauge
 
 import numpy as np
@@ -46,15 +47,29 @@ application = Flask("aidevsecops-tutorial")
 # Add Cross Origin Request Policy to all
 CORS(application)
 
-app_version = Gauge(
-    "aidevsecops_tutorial_app_version", "App version deployed", ["app_version"]
+metrics = PrometheusMetrics(
+    application,
+    group_by="endpoint"
 )
 
-model_version = Gauge(
-    "aidevsecops_tutorial_model_version", "Model version deployed", ["model_version"]
-)
+# static information as metric
+metrics.info("aidevsecops_tutorial_app_version", "App version deployed", version=__version__)
 
 model = Model()
+
+# custom metric to expose model version
+model_version_metric = metrics.info(
+    "aidevsecops_tutorial_model_version",
+    "Model version deployed",
+    model_version=model.model_version,  # label
+)
+
+
+@application.before_first_request
+def before_first_request_callback():
+    """Register callback, runs before first request to this service."""
+    model_version_metric.set(1)
+    _LOGGER.info("Running once before first request to expose metric.")
 
 
 @application.after_request
@@ -88,9 +103,6 @@ def predict():
 @application.route("/metrics")
 def metrics():
     """Return the Prometheus Metrics."""
-    app_version.labels(__version__).set(1)
-    model_version.labels(model.model_version).set(1)
-
     return generate_latest().decode("utf-8")
 
 

--- a/wsgi.py
+++ b/wsgi.py
@@ -29,7 +29,7 @@ from flask import request
 from flask import redirect
 
 from prometheus_flask_exporter import PrometheusMetrics
-from prometheus_client import generate_latest, Gauge
+from prometheus_client import generate_latest
 
 import numpy as np
 
@@ -47,18 +47,17 @@ application = Flask("aidevsecops-tutorial")
 # Add Cross Origin Request Policy to all
 CORS(application)
 
-metrics = PrometheusMetrics(
-    application,
-    group_by="endpoint"
-)
+prometheus_metrics = PrometheusMetrics(application, group_by="endpoint")
 
 # static information as metric
-metrics.info("aidevsecops_tutorial_app_version", "App version deployed", version=__version__)
+prometheus_metrics.info(
+    "aidevsecops_tutorial_app_version", "App version deployed", version=__version__
+)
 
 model = Model()
 
 # custom metric to expose model version
-model_version_metric = metrics.info(
+model_version_metric = prometheus_metrics.info(
     "aidevsecops_tutorial_model_version",
     "Model version deployed",
     model_version=model.model_version,  # label


### PR DESCRIPTION
Fixes: https://github.com/thoth-station/elyra-aidevsecops-tutorial/issues/28
Related-To:  https://github.com/thoth-station/elyra-aidevsecops-tutorial/issues/26

expose endpoints metrics:

```
# HELP flask_http_request_duration_seconds Flask HTTP request duration in seconds
# TYPE flask_http_request_duration_seconds histogram
flask_http_request_duration_seconds_bucket{endpoint="predict",le="0.005",method="POST",status="200"} 0.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="0.01",method="POST",status="200"} 0.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="0.025",method="POST",status="200"} 0.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="0.05",method="POST",status="200"} 0.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="0.075",method="POST",status="200"} 0.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="0.1",method="POST",status="200"} 0.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="0.25",method="POST",status="200"} 1.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="0.5",method="POST",status="200"} 1.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="0.75",method="POST",status="200"} 1.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="1.0",method="POST",status="200"} 1.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="2.5",method="POST",status="200"} 1.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="5.0",method="POST",status="200"} 1.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="7.5",method="POST",status="200"} 1.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="10.0",method="POST",status="200"} 1.0
flask_http_request_duration_seconds_bucket{endpoint="predict",le="+Inf",method="POST",status="200"} 1.0
flask_http_request_duration_seconds_count{endpoint="predict",method="POST",status="200"} 1.0
flask_http_request_duration_seconds_sum{endpoint="predict",method="POST",status="200"} 0.2398322420049226
# HELP flask_http_request_duration_seconds_created Flask HTTP request duration in seconds
# TYPE flask_http_request_duration_seconds_created gauge
flask_http_request_duration_seconds_created{endpoint="predict",method="POST",status="200"} 1.611658199325849e+09
# HELP flask_http_request_total Total number of HTTP requests
# TYPE flask_http_request_total counter
flask_http_request_total{method="POST",status="200"} 1.0
# HELP flask_http_request_created Total number of HTTP requests
# TYPE flask_http_request_created gauge
flask_http_request_created{method="POST",status="200"} 1.6116581993259351e+09
# HELP flask_http_request_exceptions_total Total number of HTTP requests which resulted in an exception
# TYPE flask_http_request_exceptions_total counter
# HELP aidevsecops_tutorial_app_version App version deployed
# TYPE aidevsecops_tutorial_app_version gauge
aidevsecops_tutorial_app_version{version="0.1.0"} 1.0
# HELP aidevsecops_tutorial_model_version Model version deployed
# TYPE aidevsecops_tutorial_model_version gauge
aidevsecops_tutorial_model_version{model_version="210124112759-d97fd1f46b13ee40"} 1.0
```