### PR TITLE
Deploy the Tag v0.2.2 for elyra-aidevsecops-tutorial

### DIFF
--- a/manifests/overlays/test/imagestreamtag.yaml
+++ b/manifests/overlays/test/imagestreamtag.yaml
@@ -7,7 +7,7 @@ spec:
   - name: latest
     from:
       kind: DockerImage
-      name: quay.io/thoth-station/elyra-aidevsecops-tutorial:v0.2.1
+      name: quay.io/thoth-station/elyra-aidevsecops-tutorial:v0.2.2
     importPolicy: {}
     referencePolicy:
       type: Source


### PR DESCRIPTION
Deploy the Tag v0.2.2 for elyra-aidevsecops-tutorial
Signed-off-by: Harshad Reddy Nalla <hnalla@redhat.com>

## Related Issues and Dependencies

Related-to: https://github.com/thoth-station/elyra-aidevsecops-tutorial/issues/49#issuecomment-768403516