### PR TITLE
Add latency to output of predicted model

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ You can find the images required for tutorial named after the overlays requested
 
 - [inference overlay](https://github.com/thoth-station/elyra-aidevsecops-tutorial/tree/master/overlays/inference)  -> quay.io/thoth-station/elyra-aidevsecops-tutorial:v0.4.0 (inference image)
 
-You can check the overlays build requirement in the [.acioce.yaml](https://github.com/thoth-station/elyra-aidevsecops-tutorial/blob/c86ce9c08665c12df0adf829db31bd19e8c61455/.aicoe-ci.yaml#L5).
+You can check the overlays build requirement in the [.aicoe.yaml](https://github.com/thoth-station/elyra-aidevsecops-tutorial/blob/c86ce9c08665c12df0adf829db31bd19e8c61455/.aicoe-ci.yaml#L5).
 
 All requirements for the overlay are created using Thoth resolution engine, you can find the inputs used for Thoth recommender in the [.thoth.yaml](https://github.com/thoth-station/elyra-aidevsecops-tutorial/blob/bb6fad2441e8df8aa56c2c0e6b5ac45a2cda42eb/.thoth.yaml#L5).
 

--- a/src/test.py
+++ b/src/test.py
@@ -55,4 +55,4 @@ plt.close()
 response = requests.post(test_url, data=data, headers=headers)
 
 # decode response
-print(response.text)
+print(json.loads(response.text))

--- a/wsgi.py
+++ b/wsgi.py
@@ -99,11 +99,13 @@ def predict():
     prediction, probability = model.predict(image_array=image_array)
     latency = time.monotonic() - start
 
-    return json.dumps({
-        "prediction": int(prediction),
-        "latency": latency,
-        "probability": float(probability),
-        }) 
+    return json.dumps(
+        {
+            "prediction": int(prediction),
+            "latency": latency,
+            "probability": float(probability),
+        }
+    )
 
 
 @application.route("/metrics")

--- a/wsgi.py
+++ b/wsgi.py
@@ -20,6 +20,8 @@
 
 import os
 import logging
+import time
+import json
 
 from version import __version__
 
@@ -93,11 +95,15 @@ def predict():
     # reshape
     image_array = np.array(image_list)
 
+    start = time.monotonic()
     prediction, probability = model.predict(image_array=image_array)
-    return {
-        "response": f"The number in the image is {str(prediction)}"
-        f" with probability {str(probability)}"
-    }
+    latency = time.monotonic() - start
+
+    return json.dumps({
+        "prediction": int(prediction),
+        "latency": latency,
+        "probability": float(probability),
+        }) 
 
 
 @application.route("/metrics")


### PR DESCRIPTION
Signed-off-by: Francesco Murdaca <fmurdaca@redhat.com>

```
{'prediction': 0, 'latency': 0.2583560849998321, 'probability': 1.0}
```