### PR TITLE
Fix pipeline GitHub URL

### DIFF
--- a/docs/source/create-ai-pipeline.md
+++ b/docs/source/create-ai-pipeline.md
@@ -128,7 +128,7 @@ If you want to know more, check the following [link](https://elyra.readthedocs.i
 <img alt="Elyra AI Pipeline example" src="https://raw.githubusercontent.com/thoth-station/elyra-aidevsecops-tutorial/master/docs/images/AIPipeline.png">
 </div>
 
-You can find the above pipeline [here](https://github.com/thoth-station/elyra-aidevsecops-tutorial/blob/master/elyra-aidevsecops-tutorial..pipeline).
+You can find the above pipeline [here](https://github.com/thoth-station/elyra-aidevsecops-tutorial/blob/master/elyra-aidevsecops-tutorial.pipeline).
 
 ## References
 


### PR DESCRIPTION
## Related Issues and Dependencies
The `You can find the above pipeline [here]` link results in a 404 error due to a typo in the URL.
…

## This introduces a breaking change

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->

## This Pull Request implements

Fixed the URL

## Description

<!--- Describe your changes in detail -->
